### PR TITLE
Improve naming of files and allow to subset longitudes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: map2tidy
 Title: Map Spatio-temporal NetCDF Stacks Along Time
-Version: 2.0.0
+Version: 2.0.0.9000
 Authors@R: 
     person(
       given = "Benjamin",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: map2tidy
 Title: Map Spatio-temporal NetCDF Stacks Along Time
-Version: 2.0.0.9001
+Version: 2.1.0
 Authors@R: c(
     person(
       given = "Benjamin",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,19 @@
 Package: map2tidy
 Title: Map Spatio-temporal NetCDF Stacks Along Time
 Version: 2.0.0.9000
-Authors@R: 
+Authors@R: c(
     person(
       given = "Benjamin",
       family = "Stocker",
       email = "benjamin.stocker@gmail.com",
       role = c("aut", "cre"),
-      comment = c(ORCID = "0000-0003-2697-9096")
+      comment = c(ORCID = "0000-0003-2697-9096")),
+    person(
+      given = "Fabian",
+      family = "Bernhard",
+      email = "fabian.bernhard@alumni.epfl.ch",
+      role = c("aut"),
+      comment = c(ORCID = "0000-0003-0338-0961"))
     )
 Description: Make geospatial data with a time dimension into a tidy format. Facilitates temporal analysis on a location basis.
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: map2tidy
 Title: Map Spatio-temporal NetCDF Stacks Along Time
-Version: 2.0.0.9000
+Version: 2.0.0.9001
 Authors@R: c(
     person(
       given = "Benjamin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,19 @@
+# map2tidy v2.1
+
+* Changed the naming of the files (prepending 0's to have always 6 digits: `LON_-000.250`)
+* Added a feature to subset certain longitudes only (argument `filter_lon_between_degrees`)
+* Made error messages more explicit.
+
 # map2tidy v2.0
 
 * Public release after refactored code
-
-New sine previous version:
-* Improve robustness:
+* Improved robustness:
     - `map2tidy` can now handle hourly data (using pkg `CFtime`)
     - generally more automatic handling of NetCDF files.
-* Streamline API:
+* Streamlined API:
     - function calls require less user input. Since more information is robustly derived from the data itself, the use of various data sets is facilitated.
     - Namely: get rid of input arguments: `timedimnam`, `noleap`, `res_time`
-* Improve Verbosity:
+* Improved Verbosity:
     - `map2tidy` now reports what it is doing
     - `map2tidy` now suggests alternatives if user input is wrong, e.g. typos or wrong names of ‘longituded’ etc…
     - [ ] unsolved: when `ncores > 1` verbosity remains low, since `message()` does not get printed from within `multidplyr`

--- a/R/add_loess.R
+++ b/R/add_loess.R
@@ -1,6 +1,6 @@
 add_loess <- function(df){
   # R CMD Check HACK, use .data$ syntax (or {{...}}) for correct fix https://stackoverflow.com/a/63877974
-  index <- lat <- lon <- name <- value <- out <- datetime <- lon_index <- lon_value <- data <- time <- NULL
+  index <- lat <- lon <- name <- value <- out <- datetime <- lon_value <- data <- time <- NULL
 
   # for the example in parallel_computation.Rmd
   df <- df |>

--- a/R/add_loess_byilon.R
+++ b/R/add_loess_byilon.R
@@ -1,6 +1,6 @@
 add_loess_byilon <- function(ilon){
   # R CMD Check HACK, use .data$ syntax (or {{...}}) for correct fix https://stackoverflow.com/a/63877974
-  index <- lat <- lon <- name <- value <- out <- datetime <- lon_index <- lon_value <- data <- time <- NULL
+  index <- lat <- lon <- name <- value <- out <- datetime <- lon_value <- data <- time <- NULL
 
   # for the example in parallel_computation.Rmd
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -247,9 +247,16 @@ ncfile_to_df <- function(
   if (!is.na(fgetdate)){
     # if fgetdate provided, use this function to derive time(s) from nc file name
     if (!is.na(timenam)){
+      dates_to_set <- tryCatch(
+        fgetdate(filnam), # Define a vector of dates based on a single file name
+        error = function(e) stop(sprintf(
+          " Could not derive dates with function `fgetdate` for file:\n   %s\n   Received error: %s",
+          filnam,
+          e))
+      )
       df <- df |>
         dplyr::arrange(datetime) |> # ensure properly ordered
-        dplyr::group_by(lon, lat) |> dplyr::mutate(datetime = fgetdate(filnam)) |> dplyr::ungroup()
+        dplyr::group_by(lon, lat) |> dplyr::mutate(datetime = dates_to_set) |> dplyr::ungroup()
     } else {
       warning("Ignored argument 'fgetdate', since no argument 'timenam' provided.")
     }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -84,9 +84,9 @@ nclist_to_df_byilon <- function(
     df_indices <- get_longitude_value_indices(nclist[1], lonnam)
     lon_values <- ifelse(
       is.na(ilon),
-      sprintf("%+.3f_to_%+.3f",
+      sprintf("%+08.3f_to_%+08.3f",
               min(df_indices$lon_value), max(df_indices$lon_value)),
-      sprintf("%+.3f",   # "%+.3g",
+      sprintf("%+08.3f",   # "%+.3g",
               dplyr::pull(dplyr::filter(df_indices, lon_index == ilon), "lon_value"))
     )
     outpath <- paste0(file.path(outdir, fileprefix), "_LON_", lon_values, ".rds")

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -103,7 +103,7 @@ nclist_to_df_byilon <- function(
                     lonnam = lonnam,
                     latnam = latnam,
                     timenam = timenam,
-                    fgetdate
+                    fgetdate = fgetdate
       )
     )
 

--- a/R/map2tidy.R
+++ b/R/map2tidy.R
@@ -40,7 +40,6 @@
 #'         the datetime is defined by package CFtime and can contain dates such
 #'         as "2021-02-30", which are valid for 360-day calendars but not for
 #'         POSIXt. Because of that these dates need to be parsed separately.
-#'
 #'         The function either returns this tibble or
 #'         then (if out_dir is specified) returns nothing and writes the tibble
 #'         to .rds files for each longitude value.

--- a/R/map2tidy.R
+++ b/R/map2tidy.R
@@ -64,6 +64,8 @@ map2tidy <- function(
   # R CMD Check HACK, use .data$ syntax (or {{...}}) for correct fix https://stackoverflow.com/a/63877974
   index <- lat <- lon <- name <- value <- out <- datetime <- lon_index <- lon_value <- data <- time <- NULL
 
+  stopifnot(length(nclist) >= 1)
+
   # check plausibility of argument combination
   if ((ncores > 1 || ncores=="all") && !do_chunks){
     warning("Warning: using multiple cores (ncores > 1) only takes effect when

--- a/man/map2tidy.Rd
+++ b/man/map2tidy.Rd
@@ -62,11 +62,9 @@ and nested column 'data'). Column 'data' contains requested variables
 the datetime is defined by package CFtime and can contain dates such
 as "2021-02-30", which are valid for 360-day calendars but not for
 POSIXt. Because of that these dates need to be parsed separately.
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{    The function either returns this tibble or
-    then (if out_dir is specified) returns nothing and writes the tibble
-    to .rds files for each longitude value.
-}\if{html}{\out{</div>}}
+The function either returns this tibble or
+then (if out_dir is specified) returns nothing and writes the tibble
+to .rds files for each longitude value.
 }
 \description{
 Extracts full time series from a list of NetCDF files, provided for time

--- a/man/map2tidy.Rd
+++ b/man/map2tidy.Rd
@@ -15,7 +15,8 @@ map2tidy(
   fileprefix = NA,
   ncores = 1,
   fgetdate = NA,
-  overwrite = FALSE
+  overwrite = FALSE,
+  filter_lon_between_degrees = NA
 )
 }
 \arguments{
@@ -54,6 +55,10 @@ based on the file name.}
 
 \item{overwrite}{A logical indicating whether time series files are to be
 overwritten.}
+
+\item{filter_lon_between_degrees}{Either NA (default) or a vector of two
+numbers c(lower, upper) that define a range of longitude values to process,
+e.g. c(-70, -68).}
 }
 \value{
 Generates a tibble (containing columns 'lon' (double), 'lat' (double),

--- a/tests/testthat/test_map2tidy.R
+++ b/tests/testthat/test_map2tidy.R
@@ -85,8 +85,8 @@ test_that("test map2tidy", {
   )
 
   # Load some example files:
-  df2  <- readRDS(file.path(tmpdir, "demo_data_2017_LON_-0.025_to_+1.425.rds"))
-  df2b3 <- readRDS(file.path(tmpdir, "demo_data_2017_LON_-0.025.rds"))
+  df2  <- readRDS(file.path(tmpdir, "demo_data_2017_LON_-000.025_to_+001.425.rds"))
+  df2b3 <- readRDS(file.path(tmpdir, "demo_data_2017_LON_-000.025.rds"))
 
 
   # check status

--- a/vignettes/parallel_computation.Rmd
+++ b/vignettes/parallel_computation.Rmd
@@ -2,8 +2,13 @@
 title: "Parallel computation on large data"
 author: "Beni Stocker"
 date: "2023-11-03"
-output: html_document
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{map2tidy functionality}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
+
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)


### PR DESCRIPTION
This PR:
- changes the naming of the files (prepending 0's to have always 6 digits: `-000.250`) 
- adds a feature to subset certain longitudes only (argument `filter_lon_between_degrees`)
- and makes error messages more explicit.